### PR TITLE
Use gradle build cache

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,6 @@ jobs:
           distribution: 'temurin'
 
       - name: 🐘 Run Gradle check
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: burrunan/gradle-cache-action@v1
         with:
           arguments: check


### PR DESCRIPTION
This swaps the gradle build action with another one that utilises a cache, which should speed up the builds, so we're not building from a blank slate each time.