### PR TITLE
Resolve ties pseudorandomly

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR Build
 
 on:
-  push:
+  pull_request:
     branches: [ "main" ]
 
 jobs:

--- a/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/screens/GameScreen.kt
+++ b/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/screens/GameScreen.kt
@@ -120,10 +120,11 @@ class GameScreen(
       simulationButton.isVisible = true
       return
     }
-    val bids = carnivoreActors.map { it.bid() }
+    val bids = carnivoreActors.groupBy { it.bid() }
     val showActions = carnivoreActors.map { it.showBid() }
-    val winningBid = bids.min()
-    val winner = carnivoreActors.removeAt(bids.indexOf(winningBid))
+    val winningBid = bids.keys.min()
+    val winner = bids[winningBid]!!.random()
+    carnivoreActors.remove(winner)
     val hideActions = carnivoreActors.map { it.hideBid() }
     stage.addAction(
         Actions.parallel(*showActions.toTypedArray())


### PR DESCRIPTION
The behaviour we had before would resolve a tie by picking the first person in the list and assigning them the win.

I don't know if this would cause a problem particularly, as a tie is unlikely and not very interesting. But to resolve any potential issue, this tie is now resolved pseudorandomly instead, similarly to the way it is resolved in the simulation.

Fixes #20 