### PR TITLE
Implement conservation of mass

### DIFF
--- a/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/carnivore/CarnivoreActor.kt
+++ b/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/carnivore/CarnivoreActor.kt
@@ -1,5 +1,6 @@
 package uk.co.developmentanddinosaurs.games.dinner.carnivore
 
+import com.badlogic.gdx.graphics.Color
 import com.badlogic.gdx.scenes.scene2d.Action
 import com.badlogic.gdx.scenes.scene2d.Actor
 import com.badlogic.gdx.scenes.scene2d.Stage
@@ -76,6 +77,21 @@ class CarnivoreActor(
   fun showBid(): Action =
       Actions.run {
             label.setText(bid.toString())
+            label.color = Color.WHITE
+            scroll.addAction(moveTo(image.x, image.y, 1f))
+            label.addAction(moveTo(image.x, image.y, 1f))
+          }
+          .then(delay(1f))
+
+  /**
+   * Animate the bid actors to show the carnivore bid
+   *
+   * @return the action to animate the bid actors
+   */
+  fun showNaughtyBid(): Action =
+      Actions.run {
+            label.setText(bid.toString())
+            label.color = Color.RED
             scroll.addAction(moveTo(image.x, image.y, 1f))
             label.addAction(moveTo(image.x, image.y, 1f))
           }

--- a/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/screens/GameScreen.kt
+++ b/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/screens/GameScreen.kt
@@ -120,10 +120,15 @@ class GameScreen(
       simulationButton.isVisible = true
       return
     }
-    val bids = carnivoreActors.groupBy { it.bid() }
-    val showActions = carnivoreActors.map { it.showBid() }
-    val winningBid = bids.keys.min()
-    val winner = bids[winningBid]!!.random()
+    val originalBids = carnivoreActors.groupBy { it.bid() }
+    val naughtyBids = originalBids.filter { it.key > mummyTrex.bringHomeTheBacon() }
+    val goodBids = originalBids.filter { it.key <= mummyTrex.bringHomeTheBacon() }
+    val showActions =
+        naughtyBids.values.flatten().map { it.showNaughtyBid() } +
+            goodBids.values.flatten().map { it.showBid() }
+    val winningBid = originalBids.keys.min()
+    val winner = originalBids[winningBid]!!.random()
+    val actualWinningBid = if (winningBid > mummyTrex.bringHomeTheBacon()) 0 else winningBid
     carnivoreActors.remove(winner)
     val hideActions = carnivoreActors.map { it.hideBid() }
     stage.addAction(
@@ -133,8 +138,8 @@ class GameScreen(
             .then(Actions.run { meatLabel.setText("${mummyTrex.bringHomeTheBacon()}\nkg") })
             .then(Actions.run { playRound() }),
     )
-    carnivoreActors.forEach { it.update(winningBid) }
-    mummyTrex.updateMeat(winningBid)
-    mummyTrex.evaluate(winner.codeCarnivore, winningBid)
+    carnivoreActors.forEach { it.update(actualWinningBid) }
+    mummyTrex.updateMeat(actualWinningBid)
+    mummyTrex.evaluate(winner.codeCarnivore, actualWinningBid)
   }
 }

--- a/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/screens/SimulationScreen.kt
+++ b/core/src/main/kotlin/uk/co/developmentanddinosaurs/games/dinner/screens/SimulationScreen.kt
@@ -93,12 +93,18 @@ class SimulationScreen(
   private fun playGame(): CraftyCodeCarnivore {
     val carnivores = codeCarnivores.toMutableList()
     mummyTrex.reset()
-    val meat = mummyTrex.bringHomeTheBacon()
+    var meat = mummyTrex.bringHomeTheBacon()
     codeCarnivores.forEach { it.initialise(codeCarnivores.size, meat) }
     while (carnivores.isNotEmpty()) {
       val result = playRound(carnivores)
-      mummyTrex.evaluate(result.winningCarnivore, result.winningBid)
-      mummyTrex.updateMeat(result.winningBid)
+      if (result.winningBid > meat) {
+        mummyTrex.evaluate(result.winningCarnivore, 0)
+        mummyTrex.updateMeat(0)
+      } else {
+        meat -= result.winningBid
+        mummyTrex.evaluate(result.winningCarnivore, result.winningBid)
+        mummyTrex.updateMeat(result.winningBid)
+      }
       carnivores.remove(result.winningCarnivore)
       carnivores.forEach { it.update(result.winningBid) }
     }


### PR DESCRIPTION
We were allowing carnivores to create as much meat as they want just by thinking it, where they could win a bid with more meat than the amount that is actually left.

This updates the Game to show the naughty bid in red, which then becomes a bid of zero when evaluated. I don't know why I bothered with this as the game screen isn't used all that often, but I don't know I think it's kind of cool, even if it will never actually be seen. The code isn't great, but I want to clean up the logic in general anyway.

The simulation screen has two fixes- one, you can't bid more than the amount of meat remaining, like the game screen. Second, we actually play the game now properly. Before, the amount of meat remaining was never updated in the match, which would cause obviously weird results. The meat is now updated.

Fixes #19 